### PR TITLE
Change 'Create' to 'Save' after object is created

### DIFF
--- a/src/UIOMatic/App_Plugins/UIOMatic/backoffice/uioMaticTree/edit.controller.js
+++ b/src/UIOMatic/App_Plugins/UIOMatic/backoffice/uioMaticTree/edit.controller.js
@@ -59,6 +59,7 @@ angular.module("umbraco").controller("uioMatic.ObjectEditController",
 	                } else {
 	                    uioMaticObjectResource.create($routeParams.id.split("?")[0], object).then(function (response) {
 	                        $scope.object = response.data;
+	                        $scope.id = $scope.object.Id;
 	                        $scope.objectForm.$dirty = false;
 	                        navigationService.syncTree({ tree: 'uioMaticTree', path: [-1, -1], forceReload: true });
 	                        notificationsService.success("Success", "Object has been created");


### PR DESCRIPTION
This makes sure the controller switches to the "edit" state after you create a new object, by setting `$scope.id` with the id of the new object.

This causes the Create button to update to "Save" and the header to change to "Object Editor"