### PR TITLE
Add 'return to list' button when editing from listview, combine methods

### DIFF
--- a/src/UIOMatic/App_Plugins/UIOMatic/backoffice/uioMaticTree/edit.controller.js
+++ b/src/UIOMatic/App_Plugins/UIOMatic/backoffice/uioMaticTree/edit.controller.js
@@ -9,13 +9,16 @@ angular.module("umbraco").controller("uioMatic.ObjectEditController",
 	    $scope.loaded = false;
 	    $scope.id = $routeParams.id.split("?")[0];
 
-	    var typeName = "";
+	    $scope.typeName = "";
 	    if (isNaN($routeParams.id.split("?")[0])) {
-	        typeName = $routeParams.id;
+	        $scope.typeName = $routeParams.id;
 	    } else {
-	        typeName = $routeParams.id.split("=")[1];
+	        $scope.typeName = $routeParams.id.split("=").slice(1).join('=');
 	    }
-	    uioMaticObjectResource.getAllProperties(typeName).then(function (response) {
+	    uioMaticObjectResource.getType($scope.typeName).then(function (response) {
+	        $scope.type = response.data;
+	    });
+	    uioMaticObjectResource.getAllProperties($scope.typeName).then(function (response) {
 	        $scope.properties = response.data;
 	        
 

--- a/src/UIOMatic/App_Plugins/UIOMatic/backoffice/uioMaticTree/edit.html
+++ b/src/UIOMatic/App_Plugins/UIOMatic/backoffice/uioMaticTree/edit.html
@@ -45,7 +45,12 @@
                             <button type="submit" data-hotkey="ctrl+s" class="btn btn-success" ng-hide="isNumber(id)">
                                 Create
                             </button>
+                        </div>
 
+                        <div class="btn-group" ng-show="type.RenderType == 1">
+                            <a class="btn" href="#/uiomatic/uioMaticTree/list/{{typeName}}">
+                                <localize key="buttons_returnToList">Return to list</localize>
+                            </a>
                         </div>
                     </div>
 

--- a/src/UIOMatic/App_Plugins/UIOMatic/backoffice/uioMaticTree/list.controller.js
+++ b/src/UIOMatic/App_Plugins/UIOMatic/backoffice/uioMaticTree/list.controller.js
@@ -7,9 +7,9 @@
         //    $scope.properties = response.data;
         //});
 
-        uioMaticObjectResource.getPrimaryKeyColumnName($scope.typeName).then(function (response) {
-            $scope.primaryKeyColumnName = response.data;
-            $scope.predicate = response.data;
+        uioMaticObjectResource.getType($scope.typeName).then(function (response) {
+            $scope.primaryKeyColumnName = response.data.PrimaryKeyColumnName;
+            $scope.predicate = response.data.PrimaryKeyColumnName;
 
             uioMaticObjectResource.getAll($scope.typeName).then(function (resp) {
                 $scope.rows = resp.data;

--- a/src/UIOMatic/App_Plugins/UIOMatic/uioMaticObject.resource.js
+++ b/src/UIOMatic/App_Plugins/UIOMatic/uioMaticObject.resource.js
@@ -14,8 +14,8 @@
 	        getById: function (type, id) {
 	            return $http.get(Umbraco.Sys.ServerVariables.uioMatic.ppcBaseUrl + "GetById?typeName=" + type + "&id=" + id);
 	        },
-	        getPrimaryKeyColumnName: function(type) {
-	            return $http.get(Umbraco.Sys.ServerVariables.uioMatic.ppcBaseUrl + "GetPrimaryKeyColumnName?typeName=" + type);
+	        getType: function(type) {
+	            return $http.get(Umbraco.Sys.ServerVariables.uioMatic.ppcBaseUrl + "GetType?typeName=" + type);
 	        },
 	        create: function (type, object) {
 	            var item = {};

--- a/src/UIOMatic/Controllers/PetaPocoObjectController.cs
+++ b/src/UIOMatic/Controllers/PetaPocoObjectController.cs
@@ -139,24 +139,31 @@ namespace UIOMatic.Controllers
 
         }
 
-        public string GetPrimaryKeyColumnName(string typeName)
+        public UIOMaticTypeInfo GetType(string typeName)
         {
-            var ar = typeName.Split(',');
-            var currentType = Type.GetType(ar[0] + ", " + ar[1]);
+            var currentType = Type.GetType(typeName);
+            var tableName = (TableNameAttribute)Attribute.GetCustomAttribute(currentType, typeof(TableNameAttribute));
+            var uioMaticAttri = (UIOMaticAttribute)Attribute.GetCustomAttribute(currentType, typeof(UIOMaticAttribute));
 
+            var primaryKey = "id";
             var primKeyAttri = currentType.GetCustomAttributes().Where(x => x.GetType() == typeof(PrimaryKeyAttribute));
             if (primKeyAttri.Any())
-                return ((PrimaryKeyAttribute) primKeyAttri.First()).Value;
+                primaryKey = ((PrimaryKeyAttribute)primKeyAttri.First()).Value;
 
             foreach (var property in currentType.GetProperties())
             {
                 var keyAttri = property.GetCustomAttributes().Where(x => x.GetType() == typeof(PrimaryKeyColumnAttribute));
                 if (keyAttri.Any())
-                    return property.Name;
+                    primaryKey = property.Name;
             }
 
-            return "id";
+            return new UIOMaticTypeInfo()
+            {
+                RenderType = uioMaticAttri.RenderType,
+                PrimaryKeyColumnName = primaryKey
+            };
         }
+
         public object GetById(string typeName, int id)
         {
 

--- a/src/UIOMatic/Models/UIOMaticTypeInfo.cs
+++ b/src/UIOMatic/Models/UIOMaticTypeInfo.cs
@@ -1,0 +1,11 @@
+﻿using UIOMatic.Enums;
+
+namespace UIOMatic.Models
+{
+    public class UIOMaticTypeInfo
+    {
+        public UIOMaticRenderType RenderType { get; set; }
+
+        public string PrimaryKeyColumnName { get; set; }
+    }
+}

--- a/src/UIOMatic/UIOMatic.csproj
+++ b/src/UIOMatic/UIOMatic.csproj
@@ -265,6 +265,7 @@
     <Compile Include="Interfaces\IUIOMaticModel.cs" />
     <Compile Include="Interfaces\IUIOMaticObjectController.cs" />
     <Compile Include="Models\UIOMaticPropertyInfo.cs" />
+    <Compile Include="Models\UIOMaticTypeInfo.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Sections\Section.cs" />
     <Compile Include="ServerVariableParserEvent.cs" />


### PR DESCRIPTION
Adds a "Return to list" button on the create/edit screens of types with a `RenderType` of `List`:

![image](https://cloud.githubusercontent.com/assets/1396376/10477226/6092e394-7209-11e5-8ced-99c9920d17d6.png)

To do this we needed to know whether the Type was a "list view" or not, so I added a new class `UIOMaticTypeInfo`.  I moved the `PrimaryKeyColumnName` to be a property of this to DRY things up.