### PR TITLE
Add option to ignore specific columns from listview

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,11 +88,11 @@ Desktop.ini
 
 
 # Data folders/files
-*/ExamineIndexes/*
-www/App_Data/umbraco.config
-*/App_Browsers/*
-*/App_Data/TEMP/*
-*/_systemUmbracoIndexDontDelete/*
+src/*/App_Browsers/*
+src/*/App_Data/Logs/
+src/*/App_Data/cache/
+src/*/App_Data/ExamineIndexes/*
+src/*/App_Data/TEMP/*
 
 
 # But not these files...

--- a/src/Example/Models/Dog.cs
+++ b/src/Example/Models/Dog.cs
@@ -26,6 +26,7 @@ namespace Example.Models
 
 
         [UIOMaticField("Owner", "Select the owner of the dog", View = "~/App_Plugins/Example/picker.person.html")]
+        [UIOMaticIgnoreFromListView]
         public int OwnerId { get; set; }
 
         public override string ToString()

--- a/src/UIOMatic/App_Plugins/UIOMatic/backoffice/uioMaticTree/list.controller.js
+++ b/src/UIOMatic/App_Plugins/UIOMatic/backoffice/uioMaticTree/list.controller.js
@@ -10,10 +10,13 @@
         uioMaticObjectResource.getType($scope.typeName).then(function (response) {
             $scope.primaryKeyColumnName = response.data.PrimaryKeyColumnName;
             $scope.predicate = response.data.PrimaryKeyColumnName;
+            $scope.ignoreColumnsFromListView = response.data.IgnoreColumnsFromListView;
 
             uioMaticObjectResource.getAll($scope.typeName).then(function (resp) {
                 $scope.rows = resp.data;
-                $scope.cols = Object.keys($scope.rows[0]);
+                $scope.cols = Object.keys($scope.rows[0]).filter(function (c) {
+                    return $scope.ignoreColumnsFromListView.indexOf(c) == -1;
+                });
             });
 
         });

--- a/src/UIOMatic/Atributes/UIOMaticIgnoreFromListViewAttribute.cs
+++ b/src/UIOMatic/Atributes/UIOMaticIgnoreFromListViewAttribute.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace UIOMatic.Atributes
+{
+    [AttributeUsage(AttributeTargets.Property, AllowMultiple = false, Inherited = false)]
+    public class UIOMaticIgnoreFromListViewAttribute : Attribute
+    {
+    }
+}

--- a/src/UIOMatic/Controllers/PetaPocoObjectController.cs
+++ b/src/UIOMatic/Controllers/PetaPocoObjectController.cs
@@ -145,6 +145,8 @@ namespace UIOMatic.Controllers
             var tableName = (TableNameAttribute)Attribute.GetCustomAttribute(currentType, typeof(TableNameAttribute));
             var uioMaticAttri = (UIOMaticAttribute)Attribute.GetCustomAttribute(currentType, typeof(UIOMaticAttribute));
 
+            var ignoreColumnsFromListView = new List<string>();
+
             var primaryKey = "id";
             var primKeyAttri = currentType.GetCustomAttributes().Where(x => x.GetType() == typeof(PrimaryKeyAttribute));
             if (primKeyAttri.Any())
@@ -155,12 +157,17 @@ namespace UIOMatic.Controllers
                 var keyAttri = property.GetCustomAttributes().Where(x => x.GetType() == typeof(PrimaryKeyColumnAttribute));
                 if (keyAttri.Any())
                     primaryKey = property.Name;
+
+                var ignoreAttri = property.GetCustomAttributes().Where(x => x.GetType() == typeof(UIOMaticIgnoreFromListViewAttribute));
+                if (ignoreAttri.Any())
+                    ignoreColumnsFromListView.Add(property.Name);
             }
 
             return new UIOMaticTypeInfo()
             {
                 RenderType = uioMaticAttri.RenderType,
-                PrimaryKeyColumnName = primaryKey
+                PrimaryKeyColumnName = primaryKey,
+                IgnoreColumnsFromListView = ignoreColumnsFromListView.ToArray()
             };
         }
 

--- a/src/UIOMatic/Models/UIOMaticTypeInfo.cs
+++ b/src/UIOMatic/Models/UIOMaticTypeInfo.cs
@@ -7,5 +7,7 @@ namespace UIOMatic.Models
         public UIOMaticRenderType RenderType { get; set; }
 
         public string PrimaryKeyColumnName { get; set; }
+
+        public string[] IgnoreColumnsFromListView { get; set; }
     }
 }

--- a/src/UIOMatic/UIOMatic.csproj
+++ b/src/UIOMatic/UIOMatic.csproj
@@ -258,6 +258,7 @@
     <Compile Include="Atributes\UIOMaticAttribute.cs" />
     <Compile Include="Atributes\UIOMaticFieldAttribute.cs" />
     <Compile Include="Atributes\UIOMaticIgnoreFieldAttribute.cs" />
+    <Compile Include="Atributes\UIOMaticIgnoreFromListViewAttribute.cs" />
     <Compile Include="Controllers\PetaPocoObjectController.cs" />
     <Compile Include="Controllers\PropertyEditorsApiController.cs" />
     <Compile Include="Enums\UIOMaticRenderType.cs" />
@@ -265,6 +266,7 @@
     <Compile Include="Interfaces\IUIOMaticModel.cs" />
     <Compile Include="Interfaces\IUIOMaticObjectController.cs" />
     <Compile Include="Models\UIOMaticPropertyInfo.cs" />
+    <Compile Include="Models\UIOMaticTypeInfo.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Sections\Section.cs" />
     <Compile Include="ServerVariableParserEvent.cs" />


### PR DESCRIPTION
Note, this depends on #5, merge that first before reviewing.

This adds a new attribute `UIOMaticIgnoreFromListView`, to tell the list view table not to include a property as a column.