### PR TITLE
Introduce "Object Names"

### DIFF
--- a/src/Example/Models/Dog.cs
+++ b/src/Example/Models/Dog.cs
@@ -18,7 +18,7 @@ namespace Example.Models
         [PrimaryKeyColumn(AutoIncrement = true)]
         public int Id { get; set; }
 
-
+        [UIOMaticNameField]
         public string Name { get; set; }
 
         [UIOMaticField("Is castrated", "Has the dog been castrated")]

--- a/src/UIOMatic/App_Plugins/UIOMatic/backoffice/uioMaticTree/edit.controller.js
+++ b/src/UIOMatic/App_Plugins/UIOMatic/backoffice/uioMaticTree/edit.controller.js
@@ -19,45 +19,47 @@ angular.module("umbraco").controller("uioMatic.ObjectEditController",
 	    }
 	    uioMaticObjectResource.getType($scope.typeName).then(function (response) {
 	        $scope.type = response.data;
-	    });
-	    uioMaticObjectResource.getAllProperties($scope.typeName).then(function (response) {
-	        $scope.properties = response.data;
 
-	        var tabsArr = [];
-	        angular.forEach(response.data, function (value, key) {
-	            if (this.map(function (e) { return e.label; }).indexOf(value.Tab) == -1) {
-	                if (value.Tab == "") {
-	                    this.push({ id: 99, label: "Misc" });
-	                } else {
-	                    this.push({ id: key, label: value.Tab });
+	        uioMaticObjectResource.getAllProperties($scope.typeName).then(function (response) {
+	            $scope.properties = response.data;
+	            $scope.type.NameFieldIndex = $scope.type.NameField.length > 0
+                    ? _.indexOf(_.pluck($scope.properties, "Key"), $scope.type.NameField)
+	                : -1;
+
+	            var tabsArr = [];
+	            angular.forEach(response.data, function (value, key) {
+	                if (this.map(function (e) { return e.label; }).indexOf(value.Tab) == -1) {
+	                    if (value.Tab == "") {
+	                        this.push({ id: 99, label: "Misc" });
+	                    } else {
+	                        this.push({ id: key, label: value.Tab });
+	                    }
 	                }
+	            }, tabsArr);
+	            if (tabsArr.length > 1 && tabsArr[0].id != 99) {
+	                $scope.content = { tabs: tabsArr };
 	            }
-	        }, tabsArr);
-	        if (tabsArr.length > 1 && tabsArr[0].id != 99) {
-	            $scope.content = { tabs: tabsArr };
-	        }
-	        
 
-	        if (isNaN($routeParams.id.split("?")[0])) {
-	            $scope.object = {};
-	            $scope.loaded = true;
-	        }
-	        else {
 
-	            uioMaticObjectResource.getById($routeParams.id.split("=")[1], $routeParams.id.split("?")[0]).then(function (response) {
-	                $scope.object = response.data;
-
+	            if (isNaN($routeParams.id.split("?")[0])) {
+	                $scope.object = {};
 	                $scope.loaded = true;
-	                $scope.editing = true;
-	                setValues();
+	            }
+	            else {
 
-	                $scope.$broadcast('ValuesLoaded');
-	            });
-	        }
+	                uioMaticObjectResource.getById($routeParams.id.split("=")[1], $routeParams.id.split("?")[0]).then(function (response) {
+	                    $scope.object = response.data;
+
+	                    $scope.loaded = true;
+	                    $scope.editing = true;
+	                    setValues();
+
+	                    $scope.$broadcast('ValuesLoaded');
+	                });
+	            }
+	        });
 	    });
-
 	    
-
 
 	    $scope.save = function (object) {
 
@@ -157,4 +159,13 @@ angular.module("umbraco").controller("uioMatic.ObjectEditController",
 	    };
 
 	    
-	});
+	}).filter("removeProperty", function () {
+	    return function (input, propertyKey) {
+	        if (propertyKey == null || propertyKey == "")
+	            return input;
+
+	        return input.filter(function(property) {
+	            return property.Key != propertyKey;
+	        });
+	    }
+	});;

--- a/src/UIOMatic/App_Plugins/UIOMatic/backoffice/uioMaticTree/edit.html
+++ b/src/UIOMatic/App_Plugins/UIOMatic/backoffice/uioMaticTree/edit.html
@@ -7,8 +7,13 @@
         <umb-header tabs="content.tabs">
 
             <div class="span7">
-                <h1 ng-show="editing">Object Editor</h1>
-                <h1 ng-hide="editing">Object Creator</h1>
+                <div ng-if="type.NameFieldIndex > -1">
+                    <umb-content-name placeholder="@placeholders_entername" ng-model="properties[type.NameFieldIndex].Value" />
+                </div>
+                <div ng-if="type.NameFieldIndex == -1">
+                    <h1 ng-show="isNumber(id)">Object Editor</h1>
+                    <h1 ng-hide="isNumber(id)">Object Creator</h1>
+                </div>
             </div>
 
             <div class="span5">
@@ -29,13 +34,13 @@
                 {{ object | json }}-->
                 <umb-tab ng-repeat="tab in content.tabs | filter:content.Tabs != null" id="tab{{tab.id}}" rel="{{tab.label}}">
                     <div class="umb-pane">
-                        <umb-control-group ng-repeat="property in properties | filter:{Tab: tab.label}" label="{{property.Name}}" description="{{property.Description}}">
+                        <umb-control-group ng-repeat="property in properties | removeProperty:type.NameField | filter:{Tab: tab.label}" label="{{property.Name}}" description="{{property.Description}}">
                             <div ng-include="property.View"></div>
                         </umb-control-group>
                     </div>
                 </umb-tab>
                 <div class="umb-pane" ng-if="content.tabs == null">
-                    <umb-control-group ng-repeat="property in properties | filter:{Tab: tab.label}" label="{{property.Name}}" description="{{property.Description}}">
+                    <umb-control-group ng-repeat="property in properties | removeProperty:type.NameField | filter:{Tab: tab.label}" label="{{property.Name}}" description="{{property.Description}}">
                         <div ng-include="property.View"></div>
                     </umb-control-group>
                 </div>

--- a/src/UIOMatic/App_Plugins/UIOMatic/backoffice/uioMaticTree/list.controller.js
+++ b/src/UIOMatic/App_Plugins/UIOMatic/backoffice/uioMaticTree/list.controller.js
@@ -32,6 +32,7 @@
             $scope.primaryKeyColumnName = response.data.PrimaryKeyColumnName.replace(' ', '_');
             $scope.predicate = response.data.PrimaryKeyColumnName.replace(' ', '_');
             $scope.ignoreColumnsFromListView = response.data.IgnoreColumnsFromListView;
+            $scope.nameField = response.data.NameField.replace(' ', '_');
 
             fetchData();
 
@@ -110,4 +111,13 @@
             $scope.currentPage = 1;
             fetchData();
         };
+
+        $scope.isColumnLinkable = function (column, index) {
+            if ($scope.nameField.length > 0) {
+                return column == $scope.nameField;
+            } else {
+                return index == 0
+                || (index == 1 && cols[0] == $scope.primaryKeyColumnName)
+            }
+        }
     });

--- a/src/UIOMatic/App_Plugins/UIOMatic/backoffice/uioMaticTree/list.html
+++ b/src/UIOMatic/App_Plugins/UIOMatic/backoffice/uioMaticTree/list.html
@@ -61,7 +61,7 @@
                                     <input type="checkbox" name="selectedItems[]" value="{{getObjectKey(row)}}" ng-checked="isRowSelected(row)" ng-click="toggleSelection(getObjectKey(row))"/>
                                 </td>
                                 <td ng-repeat="column in cols ">
-                                    <div ng-switch="$index == 0 || ($index == 1 && cols[0] == primaryKeyColumnName)">
+                                    <div ng-switch="isColumnLinkable(column)">
                                         <a href="#/uiomatic/uioMaticTree/edit/{{getObjectKey(row)}}%3Ftype={{typeName}}" ng-switch-when="true">{{row[column]}}</a>
                                         <span ng-switch-when="false">{{row[column]}}</span>
                                     </div>

--- a/src/UIOMatic/Attributes/UIOMaticNameFieldAttribute.cs
+++ b/src/UIOMatic/Attributes/UIOMaticNameFieldAttribute.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace UIOMatic.Attributes
+{
+    [AttributeUsage(AttributeTargets.Property, AllowMultiple = false, Inherited = false)]
+    public class UIOMaticNameFieldAttribute : Attribute
+    {
+    }
+}

--- a/src/UIOMatic/Controllers/PetaPocoObjectController.cs
+++ b/src/UIOMatic/Controllers/PetaPocoObjectController.cs
@@ -258,6 +258,7 @@ namespace UIOMatic.Controllers
             var uioMaticAttri = (UIOMaticAttribute)Attribute.GetCustomAttribute(currentType, typeof(UIOMaticAttribute));
 
             var ignoreColumnsFromListView = new List<string>();
+            var nameField = "";
 
             var primaryKey = "id";
             var primKeyAttri = currentType.GetCustomAttributes().Where(x => x.GetType() == typeof(PrimaryKeyAttribute));
@@ -273,13 +274,18 @@ namespace UIOMatic.Controllers
                 var ignoreAttri = property.GetCustomAttributes().Where(x => x.GetType() == typeof(UIOMaticIgnoreFromListViewAttribute));
                 if (ignoreAttri.Any())
                     ignoreColumnsFromListView.Add(property.Name);
+
+                var nameAttri = property.GetCustomAttributes().Where(x => x.GetType() == typeof(UIOMaticNameFieldAttribute));
+                if (nameAttri.Any())
+                    nameField = property.Name;
             }
 
             return new UIOMaticTypeInfo()
             {
                 RenderType = uioMaticAttri.RenderType,
                 PrimaryKeyColumnName = primaryKey,
-                IgnoreColumnsFromListView = ignoreColumnsFromListView.ToArray()
+                IgnoreColumnsFromListView = ignoreColumnsFromListView.ToArray(),
+                NameField = nameField
             };
         }
 

--- a/src/UIOMatic/Models/UIOMaticTypeInfo.cs
+++ b/src/UIOMatic/Models/UIOMaticTypeInfo.cs
@@ -9,5 +9,7 @@ namespace UIOMatic.Models
         public string PrimaryKeyColumnName { get; set; }
 
         public string[] IgnoreColumnsFromListView { get; set; }
+
+        public string NameField { get; set; }
     }
 }

--- a/src/UIOMatic/UIOMatic.csproj
+++ b/src/UIOMatic/UIOMatic.csproj
@@ -260,6 +260,7 @@
     <Compile Include="Attributes\UIOMaticFieldAttribute.cs" />
     <Compile Include="Attributes\UIOMaticIgnoreFieldAttribute.cs" />
     <Compile Include="Attributes\UIOMaticIgnoreFromListViewAttribute.cs" />
+    <Compile Include="Attributes\UIOMaticNameFieldAttribute.cs" />
     <Compile Include="Config.cs" />
     <Compile Include="Controllers\ObjectController.cs" />
     <Compile Include="Controllers\PetaPocoObjectController.cs" />


### PR DESCRIPTION
This adds a new attribute that can (optionally) be used to tell UIOMatic which Property is meant to be the Name of your object.

````csharp
[UIOMaticNameField]
public string Name { get; set; }
````

When specified, the object name will be editable from the header of the screen, just like when editing Umbraco content nodes.  Also, specifying the Name field will cause it to be the linkable column in the list view.

![image](https://cloud.githubusercontent.com/assets/1396376/10955221/3c766e0e-8307-11e5-8021-14fb7593f81a.png)

For #8 