### PR TITLE
Fix console error when filter executes before scope populated

### DIFF
--- a/src/UIOMatic/App_Plugins/UIOMatic/backoffice/uioMaticTree/edit.controller.js
+++ b/src/UIOMatic/App_Plugins/UIOMatic/backoffice/uioMaticTree/edit.controller.js
@@ -174,7 +174,7 @@ angular.module("umbraco").controller("uioMatic.ObjectEditController",
 
 	}).filter("removeProperty", function () {
 	    return function (input, propertyKey) {
-	        if (propertyKey == null || propertyKey == "")
+	        if (propertyKey == null || propertyKey == "" || input == null)
 	            return input;
 
 	        return input.filter(function (property) {


### PR DESCRIPTION
as reported [here](https://github.com/TimGeyssens/UIOMatic/issues/8#issuecomment-162722614)