### PR TITLE
Remove unused dropdown attributes to avoid JS error

### DIFF
--- a/src/UIOMatic/App_Plugins/UIOMatic/backoffice/uioMaticTree/list.html
+++ b/src/UIOMatic/App_Plugins/UIOMatic/backoffice/uioMaticTree/list.html
@@ -24,7 +24,7 @@
                  
                     <div class="umb-sub-header">
                         <div class="btn-group" ng-hide="readOnly">
-                            <a class="btn dropdown-toggle" data-toggle="dropdown" href="#/uiomatic/uioMaticTree/edit/{{typeName}}">
+                            <a class="btn" href="#/uiomatic/uioMaticTree/edit/{{typeName}}">
                                 <localize key="actions_create" class="ng-isolate-scope ng-scope">Create</localize>
                             </a>
                         </div>


### PR DESCRIPTION
We noticed some intermittent JS errors being generated while using the UIOMatic section.  You can reproduce this by clicking "Dogs" in the tree, then clicking "Dogs" again:

![image](https://cloud.githubusercontent.com/assets/1396376/16623135/bcf07326-436a-11e6-8c19-74f541adb72d.png)

The problem seems to be related to the Bootstrap dropdown menu on the Create button.  Since UIOMatic only supports one "type" for creating, I just removed the bootstrap dropdown attributes to avoid the error.