### PR TITLE
Add DateTimeOffset support

### DIFF
--- a/src/Example/Example.csproj
+++ b/src/Example/Example.csproj
@@ -265,6 +265,7 @@
     <Compile Include="Models\Test.cs" />
     <Compile Include="Models\TestWithDateCopy.cs" />
     <Compile Include="Models\TestWithDate.cs" />
+    <Compile Include="Models\TestWithDateTimeOffset.cs" />
     <Compile Include="Models\umbracoLog.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Startup.cs" />

--- a/src/Example/Models/TestWithDateTimeOffset.cs
+++ b/src/Example/Models/TestWithDateTimeOffset.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections.Generic;
+
+using UIOMatic.Attributes;
+using UIOMatic.Interfaces;
+using Umbraco.Core.Persistence;
+using Umbraco.Core.Persistence.DatabaseAnnotations;
+
+namespace Example.Models
+{
+    [UIOMatic(name: "TestWithDateTimeOffset", folderIcon: "icon-users", itemIcon: "icon-user", RenderType = UIOMatic.Enums.UIOMaticRenderType.List, ReadOnly = false)]
+    [TableName("TestWithDateTimeOffset")]
+    [PrimaryKey("Id", autoIncrement = true)]
+    public class TestWithDateTimeOffset : IUIOMaticModel
+    {
+        [UIOMaticIgnoreField]
+        [PrimaryKeyColumn(AutoIncrement = true)]
+        public int Id { get; set; }
+
+        [UIOMaticField("Firstname", "Enter your firstname")]
+        public string FirstName { get; set; }
+
+        [UIOMaticField("Lastname", "Enter your lastname")]
+        public string LastName { get; set; }
+
+        [UIOMaticField("TheDateTimeOffset", "select a date")]
+        public DateTimeOffset TheDateTimeOffset { get; set; }
+
+        public IEnumerable<Exception> Validate()
+        {
+            return new List<Exception>();
+        }
+    }
+}

--- a/src/UIOMatic/App_Plugins/UIOMatic/backoffice/views/datetimeoffset.controller.js
+++ b/src/UIOMatic/App_Plugins/UIOMatic/backoffice/views/datetimeoffset.controller.js
@@ -1,0 +1,56 @@
+﻿angular.module("umbraco").controller("UIOMatic.Views.DateTimeOffset",
+	function ($scope, $element, $timeout, assetsService, angularHelper) {
+
+	    var DATE_FORMAT = 'YYYY-MM-DD HH:mm:ss';
+
+	    //setup the default config
+	    var config = {
+	        pickDate: true,
+	        pickTime: true,
+	        useSeconds: true,
+	        format: DATE_FORMAT,
+	        icons: {
+	            time: "icon-time",
+	            date: "icon-calendar",
+	            up: "icon-chevron-up",
+	            down: "icon-chevron-down"
+	        }
+	    };
+
+	    $scope.config = angular.extend(config, $scope.config);
+
+	    function applyDate(e) {
+	        angularHelper.safeApply($scope, function () {
+	            // when a date is changed, update the model
+	            if (e.date) {
+	                $scope.property.Value = e.date.format(DATE_FORMAT) + $scope.property.offset;
+	            }
+	        });
+	    };
+
+	    var filesToLoad = ["lib/moment/moment-with-locales.js",
+            "lib/datetimepicker/bootstrap-datetimepicker.js"];
+
+	    assetsService.load(filesToLoad).then(
+	        function () {
+	            $scope.property.viewValue = moment.parseZone($scope.property.Value).format(DATE_FORMAT);
+	            $scope.property.offset = moment.parseZone($scope.property.Value).format("Z");
+
+	            // It's important to remove the T from the value to make sure
+	            // web api bind this as a string and not as a DateTime because
+	            // when it does so, it converts the DateTimeOffset to a local
+	            // DateTime.
+	            $scope.property.Value = $scope.property.Value.replace('T', ' ');
+
+	            // The $timeout 0 is a little hack to delay the execution of this 
+	            // code on the call stack and be sure the viewValue property is 
+	            // fully loaded. Without this delay, when the users select a 
+	            // different date the time would change to the current time.
+	            $timeout(function () {
+	                $element.find("div:first")
+                        .datetimepicker($scope.config)
+                        .on("dp.change", applyDate);
+	            }, 0);
+	        });
+
+	});

--- a/src/UIOMatic/App_Plugins/UIOMatic/backoffice/views/datetimeoffset.html
+++ b/src/UIOMatic/App_Plugins/UIOMatic/backoffice/views/datetimeoffset.html
@@ -1,0 +1,9 @@
+﻿<div ng-controller="UIOMatic.Views.DateTimeOffset">
+    <div class="input-append date datepicker" style="position: relative;" id="datepicker{{property.Name}}">
+        <input name="datepicker" data-format="YYYY-MM-DD HH:mm:ss" type="text"
+               ng-model="property.viewValue" />
+        <span class="add-on">
+            <i class="icon-calendar"></i>
+        </span>
+    </div>
+</div>

--- a/src/UIOMatic/App_Plugins/UIOMatic/package.manifest
+++ b/src/UIOMatic/App_Plugins/UIOMatic/package.manifest
@@ -87,6 +87,7 @@
 		'~/App_Plugins/UIOMatic/backoffice/views/file.controller.js',
 		'~/App_Plugins/UIOMatic/backoffice/views/date.controller.js',
 		'~/App_Plugins/UIOMatic/backoffice/views/datetime.controller.js',
+		'~/App_Plugins/UIOMatic/backoffice/views/datetimeoffset.controller.js',
 		'~/App_Plugins/UIOMatic/backoffice/views/dropdown.controller.js',
 		'~/App_Plugins/UIOMatic/backoffice/views/pickers.content.controller.js',
 		'~/App_Plugins/UIOMatic/backoffice/views/pickers.media.controller.js',

--- a/src/UIOMatic/Controllers/PetaPocoObjectController.cs
+++ b/src/UIOMatic/Controllers/PetaPocoObjectController.cs
@@ -231,6 +231,8 @@ namespace UIOMatic.Controllers
                                 view = "~/App_Plugins/UIOMatic/Backoffice/Views/checkbox.html";
                             if (prop.PropertyType == typeof(DateTime) && attri.View == "textfield")
                                 view = "~/App_Plugins/UIOMatic/Backoffice/Views/datetime.html";
+                            if (prop.PropertyType == typeof(DateTimeOffset) && attri.View == "textfield")
+                                view = "~/App_Plugins/UIOMatic/Backoffice/Views/datetimeoffset.html";
                             if ((prop.PropertyType == typeof(int) | prop.PropertyType == typeof(long)) && attri.View == "textfield")
                                 view = "~/App_Plugins/UIOMatic/Backoffice/Views/number.html";
                             var pi = new UIOMaticPropertyInfo
@@ -254,6 +256,8 @@ namespace UIOMatic.Controllers
                                 view = "~/App_Plugins/UIOMatic/Backoffice/Views/checkbox.html";
                             if (prop.PropertyType == typeof(DateTime))
                                 view = "~/App_Plugins/UIOMatic/Backoffice/Views/datetime.html";
+                            if (prop.PropertyType == typeof(DateTimeOffset))
+                                view = "~/App_Plugins/UIOMatic/Backoffice/Views/datetimeoffset.html";
                             if (prop.PropertyType == typeof(int) | prop.PropertyType == typeof(long))
                                 view = "~/App_Plugins/UIOMatic/Backoffice/Views/number.html";
                             var pi = new UIOMaticPropertyInfo

--- a/src/UIOMatic/Helper.cs
+++ b/src/UIOMatic/Helper.cs
@@ -77,6 +77,7 @@ namespace UIOMatic
             }
             if (value is string && type == typeof(Guid)) return new Guid(value as string);
             if (value is string && type == typeof(Version)) return new Version(value as string);
+            if (value is string && type == typeof(DateTimeOffset)) return DateTimeOffset.Parse(value as string);
             if (!(value is IConvertible)) return value;
             return Convert.ChangeType(value, type);
         } 

--- a/src/UIOMatic/UIOMatic.csproj
+++ b/src/UIOMatic/UIOMatic.csproj
@@ -309,6 +309,8 @@
     <Content Include="App_Plugins\UIOMatic\backoffice\views\checkboxlist.html" />
     <Content Include="App_Plugins\UIOMatic\backoffice\views\date.html" />
     <Content Include="App_Plugins\UIOMatic\backoffice\views\date.controller.js" />
+    <Content Include="App_Plugins\UIOMatic\backoffice\views\datetimeoffset.controller.js" />
+    <Content Include="App_Plugins\UIOMatic\backoffice\views\datetimeoffset.html" />
     <Content Include="App_Plugins\UIOMatic\backoffice\views\datetime.controller.js" />
     <Content Include="App_Plugins\UIOMatic\backoffice\views\datetime.html" />
     <Content Include="App_Plugins\UIOMatic\backoffice\views\dropdown.controller.js" />


### PR DESCRIPTION
We found out that UI-O-Matic doesn't play well with DateTimeOffset fields. The problem is that the server can't parse the values correctly. Also, a DateTimeOffset value can't be treated like a regular DateTime value on the frontend.

This adds a new view type for DateTimeOffset fields to handle the special details and parse the values correctly on the server.

As SQL Server CE doesn't support DateTimeOffset, this must be tested against a full SQL Server. Here's the sql script to create a test table:

```
CREATE TABLE TestWithDateTimeOffset(
	Id INT IDENTITY NOT NULL,
	FirstName nvarchar(50) NOT NULL,
	LastName nvarchar(50) NOT NULL,
	TheDateTimeOffset DATETIMEOFFSET(0) NOT NULL
);


INSERT INTO TestWithDateTimeOffset(FirstName, LastName, TheDateTimeOffset) VALUES
('foo','bar','2016-10-10 10:25:57 +02:00'),
('john','doe','2016-10-10 11:40:35 +02:00');

```