### PR TITLE
Fix issue with OnCreatedObject event not firing

### DIFF
--- a/src/UIOMatic/Services/PetaPocoObjectService.cs
+++ b/src/UIOMatic/Services/PetaPocoObjectService.cs
@@ -63,7 +63,7 @@ namespace UIOMatic.Services
             obj = repo.Create(obj);
 
             var a2 = new ObjectEventArgs(typeInfo.Type, obj);
-            UIOMaticObjectService.OnCreatingObject(a2);
+            UIOMaticObjectService.OnCreatedObject(a2);
 
             return a2.Object;
         }


### PR DESCRIPTION
Rename event so OnCreatedObject event is fired, instead of firing OnCreatingObject twice.