### PR TITLE
Fix Translation for Tree Header

### DIFF
--- a/src/UIOMatic/Web/Controllers/UIOMaticTreeController.cs
+++ b/src/UIOMatic/Web/Controllers/UIOMaticTreeController.cs
@@ -14,7 +14,7 @@ using Umbraco.Web.Trees;
 
 namespace UIOMatic.Web.Controllers
 {
-    [Tree("uiomatic", "uiomatic", "UI-O-Matic")]
+    [Tree("uiomatic", "uiomatic", null)]
     [PluginController("UIOMatic")]
     public class UIOMaticTreeController : TreeController
     {


### PR DESCRIPTION
I have renamed **UI-O-Matic** to **Reporting** using the translation files. However, as shown in the pic below, the tree header is not using the translated string.

![image](https://user-images.githubusercontent.com/1254134/33439872-602c2300-d5e6-11e7-9815-f1a2bc7df10d.png)

This might be due to the following [issue](https://our.umbraco.org/forum/extending-umbraco-and-using-the-api/76754-localised-title-using-treeattribute#comment-245341).