### PR TITLE
Added step attribute to input number field with default fallback

### DIFF
--- a/src/UIOMatic/Web/UI/App_Plugins/UIOMatic/backoffice/views/fieldeditors/number.html
+++ b/src/UIOMatic/Web/UI/App_Plugins/UIOMatic/backoffice/views/fieldeditors/number.html
@@ -3,4 +3,5 @@
        ng-model="property.value"
        min="{{property.config && property.config.min !== undefined ? property.config.min : Number.MIN_VALUE }}"
        max="{{property.config && property.config.max !== undefined ? property.config.max : Number.MAX_VALUE }}"
+       step="{{property.config && property.config.step !== undefined ? property.config.step : 'any' }}"
        />

--- a/src/UIOMatic/Web/UI/App_Plugins/UIOMatic/backoffice/views/fieldeditors/number.html
+++ b/src/UIOMatic/Web/UI/App_Plugins/UIOMatic/backoffice/views/fieldeditors/number.html
@@ -3,5 +3,5 @@
        ng-model="property.value"
        min="{{property.config && property.config.min !== undefined ? property.config.min : Number.MIN_VALUE }}"
        max="{{property.config && property.config.max !== undefined ? property.config.max : Number.MAX_VALUE }}"
-       step="{{property.config && property.config.step !== undefined ? property.config.step : 'any' }}"
-       />
+       step="{{property.config && property.config.step !== undefined ? property.config.step : 1 }}"
+/>


### PR DESCRIPTION
I observed lack of step attribute in the input type="number" field which was causing validation issues for my properties. By default, it enables only steps incremented by 1, when for example I was declaring decimal types for my properties and couldn't save proper values because of the client-side validation.

Reference: https://www.isotoma.com/blog/2012/03/02/html5-input-typenumber-and-decimalsfloats-in-chrome/

I've gone the 'simple way', adding the additional attribute with config property and default fallback. Don't know if it's necessary to create separated field editor - it's up to you. Same with deciding which behaviour should be default - maybe we should place step = 'any' as default? I finally took 1 as a default to not force current implementations to fail when it's used for ints etc.

Now my config for decimal type looks like this:

```
[Required]
[NullSetting(NullSetting = NullSettings.Null)]
[UIOMaticField(View = UIOMatic.Constants.FieldEditors.Number, Config = "{ 'step': 'any' }")]
public decimal? CoursePrice { get; set; }
```