### PR TITLE
Use primaryKeyColumnName instead of id;

### DIFF
--- a/src/UIOMatic/Web/UI/App_Plugins/UIOMatic/backoffice/uiomatic/edit.controller.js
+++ b/src/UIOMatic/Web/UI/App_Plugins/UIOMatic/backoffice/uiomatic/edit.controller.js
@@ -128,7 +128,7 @@ angular.module("umbraco").controller("uioMatic.ObjectEditController",
 	                } else {
 	                    uioMaticObjectResource.create($scope.typeAlias, object).then(function (response) {
 	                        $scope.objectForm.$dirty = false;
-	                        var redirectUrl = "/uiomatic/uiomatic/edit/" + response.Id + "%3Fta=" + $scope.typeAlias;
+                            var redirectUrl = "/uiomatic/uiomatic/edit/" + response[$scope.type.primaryKeyColumnName] + "%3Fta=" + $scope.typeAlias;
 	                        for (var k in $scope.queryString) {
 	                            if ($scope.queryString.hasOwnProperty(k) && k != "ta") {
 	                                redirectUrl += "%26" + encodeURIComponent(k) + "=" + encodeURIComponent(encodeURIComponent($scope.queryString[k]));


### PR DESCRIPTION
Use the primary key column name instead of just the Id. If your primary key column is not named as Id, the code is not working properly. Creating a new element won't redirect you to the new object.