### PR TITLE
Allow for cascading dropdowns

### DIFF
--- a/docs/02.DefaultEditorViews.md
+++ b/docs/02.DefaultEditorViews.md
@@ -83,6 +83,17 @@ The dropdown requires additional configuration.
 		   Config = "{'typeAlias': 'person', 'valueColumn': 'Id', 'sortColumn': 'FirstName', 'textTemplate' : '{{FirstName}} {{LastName}}'}")]
 		public int OwnerId { get; set; }
 
+Create optional cascading or filtered dropbox options
+
+- foreignKeyColumn : 'PropertyOnRelatedObject'
+- foreignKeyValueAlias : 'PropertyOfCurrentObjectToFilterOn'
+
+		[UIOMaticField(Description = "Select the the dog", View = UIOMatic.Constants.FieldEditors.Dropdown,
+		   Config = "{'typeAlias': 'dog', 'valueColumn': 'Id', 'sortColumn': 'Name', 'textTemplate' : '{{Name}}'},
+		   'foreignKeyColumn' : 'OwnerId', 'foreignKeyValueAlias' : 'OwnerId'}")]
+		public int DogId { get; set; }
+
+
 ## File ##
 Renders a file picker (allows you to select a file from the media library, will store the path to the selected file).
 

--- a/src/UIOMatic/Web/UI/App_Plugins/UIOMatic/backoffice/views/fieldeditors/dropdown.controller.js
+++ b/src/UIOMatic/Web/UI/App_Plugins/UIOMatic/backoffice/views/fieldeditors/dropdown.controller.js
@@ -1,15 +1,60 @@
 ﻿angular.module("umbraco").controller("UIOMatic.FieldEditors.Dropdown",
-    function ($scope, $interpolate, uioMaticObjectResource) {
+    function ($rootScope, $scope, editorState, $interpolate, uioMaticObjectResource) {
 
         function init() {
-            uioMaticObjectResource.getAll($scope.property.config.typeAlias, $scope.property.config.sortColumn, "asc").then(function (response) {
-                $scope.items = response.map(function(itm) {
-                    return {
-                        value: itm[$scope.property.config.valueColumn],
-                        text: $interpolate($scope.property.config.textTemplate)(itm)
-                    }
-                });
-            });
+            load();
+            $rootScope.$broadcast('dropdownChanged', $scope.property);
+        }
+
+        function load(value) {
+
+            if ($scope.property.config.foreignKeyColumn) {
+                // foreignKey Filter
+                var filterValue = (value || $scope.$parent.object[$scope.property.config.foreignKeyValueAlias]);
+                if (filterValue) {
+                    uioMaticObjectResource.getPaged($scope.property.config.typeAlias,
+                        1000,
+                        1,
+                        $scope.property.config.sortColumn,
+                        "asc",
+                        $scope.property.config.foreignKeyColumn +
+                        "|" +
+                        filterValue,
+                        "").then(function(response) {
+                        $scope.items = response.items.map(function(itm) {
+                            return {
+                                value: itm[$scope.property.config.valueColumn],
+                                text: $interpolate($scope.property.config.textTemplate)(itm)
+                            }
+                        });
+                    });
+                } else {
+                    $scope.items = [];
+                }
+            } else {
+                // All
+                uioMaticObjectResource
+                    .getAll($scope.property.config.typeAlias, $scope.property.config.sortColumn, "asc").then(
+                        function(response) {
+                            $scope.items = response.map(function(itm) {
+                                return {
+                                    value: itm[$scope.property.config.valueColumn],
+                                    text: $interpolate($scope.property.config.textTemplate)(itm)
+                                }
+                            });
+                        });
+            }
+        }
+
+        // TODO: There has to be a better way to do this....
+        var unregisterEventListner = $rootScope.$on('dropdownChanged', function (event, data) {
+            if (data.key === $scope.property.config.foreignKeyValueAlias) {
+                load(data.value);
+            }
+        });
+
+        $scope.onChange = function () {
+            $rootScope.$broadcast('dropdownChanged', $scope.property);
         }
 
         if ($scope.valuesLoaded) {
@@ -20,5 +65,9 @@
                 unsubscribe();
             });
         }
-        
+
+        // Unregister
+        $scope.$on('$destroy', function () {
+            unregisterEventListner();
+        });
     });

--- a/src/UIOMatic/Web/UI/App_Plugins/UIOMatic/backoffice/views/fieldeditors/dropdown.html
+++ b/src/UIOMatic/Web/UI/App_Plugins/UIOMatic/backoffice/views/fieldeditors/dropdown.html
@@ -1,5 +1,5 @@
 ﻿<div ng-controller="UIOMatic.FieldEditors.Dropdown">
-    <select ng-model="property.value" ng-options="item.value as item.text for item in items">
+    <select ng-model="property.value" ng-options="item.value as item.text for item in items" ng-change="onChange()">
         <option value="">---Please select---</option>
     </select><br>
 </div>


### PR DESCRIPTION
We are using this to show cascading dropboxs

The broadcast events seems a little hacky but I don't know of a better way (I miss Vue)

```
    [UIOMaticField(Name = "Report Type", View = Constants.FieldEditors.Dropdown,
        Config = "{'typeAlias': 'ReportType', 'valueColumn': 'Id', 'sortColumn': 'Name', 'textTemplate' : '{{Name}}'}", Order = -10)]
    public new Guid? ReportTypeId { get; set; }

    [UIOMaticField(Name = "Option Class",
         View = Constants.FieldEditors.Dropdown,
        Config =
            "{typeAlias: 'ReportOptionClass', 'valueColumn': 'Id', 'sortColumn': 'Title', 'textTemplate' : '{{Title}}', 'foreignKeyColumn' : 'ReportTypeId', 'foreignKeyValueAlias' : 'ReportTypeId'}")]
    public override Guid? ReportOptionClassId { get; set; }

```


