### PR TITLE
Various bug fixes

### DIFF
--- a/src/UIOMatic/Web/UI/App_Plugins/UIOMatic/backoffice/uiomatic/edit.controller.js
+++ b/src/UIOMatic/Web/UI/App_Plugins/UIOMatic/backoffice/uiomatic/edit.controller.js
@@ -5,6 +5,7 @@ angular.module("umbraco").controller("uioMatic.ObjectEditController",
 
         $scope.loaded = false;
         $scope.editing = false;
+        $scope.currentSection = $routeParams.section || 'uiomatic';
 
         var urlParts = $routeParams.id.split("?");
         var id = urlParts[0];
@@ -31,7 +32,7 @@ angular.module("umbraco").controller("uioMatic.ObjectEditController",
         }
 
         $scope.queryString = qs;
-        $scope.returnUrl = qs["returnUrl"] || "/uiomatic/uiomatic/list/" + $scope.typeAlias;
+        $scope.returnUrl = qs["returnUrl"] || "/" + $scope.currentSection + "/uiomatic/list/" + $scope.typeAlias;
         $scope.fromList = !!qs["returnUrl"]; // Assumes a return URL means you've come from a list field view
         $scope.syncTree = !$scope.fromList; // Don't sync the tree if we are a nested type
 
@@ -129,7 +130,7 @@ angular.module("umbraco").controller("uioMatic.ObjectEditController",
                     } else {
                         uioMaticObjectResource.create($scope.typeAlias, object).then(function (response) {
                             $scope.objectForm.$dirty = false;
-                            var redirectUrl = "/uiomatic/uiomatic/edit/" + response[$scope.type.primaryKeyColumnName] + "%3Fta=" + $scope.typeAlias;
+                            var redirectUrl = "/" + $scope.currentSection + "/uiomatic/edit/" + response[$scope.type.primaryKeyColumnName] + "%3Fta=" + $scope.typeAlias;
                             for (var k in $scope.queryString) {
                                 if ($scope.queryString.hasOwnProperty(k) && k != "ta") {
                                     redirectUrl += "%26" + encodeURIComponent(k) + "=" + encodeURIComponent(encodeURIComponent($scope.queryString[k]));
@@ -168,7 +169,7 @@ angular.module("umbraco").controller("uioMatic.ObjectEditController",
         $scope.navigate = function (url) {
             // Because some JS seems to be translating any links starting '#'
             $location.url(url);
-        }
+        };
 
         $scope.$on("valuesLoaded", function () {
             $timeout(function () {
@@ -200,5 +201,5 @@ angular.module("umbraco").controller("uioMatic.ObjectEditController",
             return input.filter(function (property) {
                 return property.key != namePropertyKey;
             });
-        }
-    });;
+        };
+    });

--- a/src/UIOMatic/Web/UI/App_Plugins/UIOMatic/backoffice/uiomatic/edit.html
+++ b/src/UIOMatic/Web/UI/App_Plugins/UIOMatic/backoffice/uiomatic/edit.html
@@ -42,21 +42,29 @@
 
         <umb-editor-container>
             <div class="tab-content form-horizontal">
+                <div ng-if="content.tabs !== null">
+                    <ng-form name="tabbedContentForm">
+                        <div class="umb-group-panel" data-app-anchor="{{group.id}}" data-element="group-{{group.id}}" ng-repeat="group in content.tabs track by group.label">
 
-                <umb-tab ng-repeat="tab in content.tabs | filter:tab != null" id="tab{{tab.id}}" rel="{{tab.label}}">
-                    <div class="umb-pane">
-                        <div ng-repeat="property in properties | removeProperty:type.nameFieldKey | filter:{tab: tab.label}">
-                            <umb-control-group label="{{property.name}}" description="{{property.description}}" ng-if="!queryString[property.columnName]">
-                                <div ng-include="property.view"></div>
-                            </umb-control-group>
+                            <div class="umb-group-panel__header">
+                                <div id="group-{{group.id}}">{{ group.label }}</div>
+                            </div>
+
+                            <div class="umb-group-panel__content">
+                                <div class="umb-property" ng-repeat="property in properties | removeProperty:type.nameFieldKey | filter:{tab: group.label}">
+                                    <umb-control-group label="{{property.name}}" description="{{property.description}}" ng-if="!queryString[property.columnName]">
+                                        <div ng-include="property.view"></div>
+                                    </umb-control-group>
+                                </div>
+                            </div>
+
                         </div>
-                    </div>
-                </umb-tab>
+                    </ng-form>
+                </div>
 
-                <div class="umb-group-panel" ng-if="content.tabs == null">
+                <div class="umb-group-panel" ng-if="content.tabs === null">
                     <div class="umb-group-panel__content">
-
-                        <div ng-repeat="property in properties | removeProperty:type.nameFieldKey | filter:{tab: tab.label}">
+                        <div class="umb-property" ng-repeat="property in properties | removeProperty:type.nameFieldKey">
                             <umb-control-group label="{{property.name}}" description="{{property.description}}" ng-if="!queryString[property.columnName]">
                                 <div ng-include="property.view"></div>
                             </umb-control-group>

--- a/src/UIOMatic/Web/UI/App_Plugins/UIOMatic/backoffice/uiomatic/list.controller.js
+++ b/src/UIOMatic/Web/UI/App_Plugins/UIOMatic/backoffice/uiomatic/list.controller.js
@@ -4,6 +4,7 @@
         var searchTimeout;
 
         $scope.dropdown = {};
+        $scope.currentSection = $routeParams.section || 'uiomatic';
         $scope.dropdown.isOpen = false;
 
         $scope.typeAlias = $routeParams.id;
@@ -210,11 +211,16 @@
 
         $scope.openAction = function (action) {
             editorService.open({
-                template: action.view,
-                show: true,
+                view: action.view,
                 dialogData: {
                     typeAlias: $scope.typeAlias,
                     config: action.config
+                },
+                submit: function () {
+                    editorService.close();
+                },
+                close: function () {
+                    editorService.close();
                 }
             });
         }

--- a/src/UIOMatic/Web/UI/App_Plugins/UIOMatic/backoffice/uiomatic/list.html
+++ b/src/UIOMatic/Web/UI/App_Plugins/UIOMatic/backoffice/uiomatic/list.html
@@ -38,7 +38,7 @@
 
                 <div class="umb-editor-sub-header__content-left">
                     <div class="btn-group" ng-hide="readOnly">
-                        <a class="btn btn-white" ng-click="navigate('/uiomatic/uiomatic/edit/' + typeAlias)">
+                        <a class="btn btn-white" ng-click="navigate('/' + currentSection + '/uiomatic/edit/' + typeAlias)">
                             <localize key="actions_create" class="ng-isolate-scope ng-scope">Create</localize>
                         </a>
                     </div>
@@ -92,7 +92,7 @@
                             <td ng-repeat="prop in properties">
                                 <div ng-switch="isColumnLinkable(prop, $index)" ng-init="property = {value:row[prop.key], view:prop.view, config:prop.config}">
                                     <!-- Fake property object so we can reuse views -->
-                                    <a class="table__link" ng-click="navigate('/uiomatic/uiomatic/edit/' + getObjectKey(row) + '%3Fta=' + typeAlias)" ng-switch-when="true">
+                                    <a class="table__link" ng-click="navigate('/' + currentSection + '/uiomatic/edit/' + getObjectKey(row) + '%3Fta=' + typeAlias)" ng-switch-when="true">
                                         <span ng-include="prop.view"></span>
                                     </a>
                                     <span ng-switch-when="false">


### PR DESCRIPTION
I was using this in a V8 project, and came across a few minor changes that I thought might be useful to contribute back.  These are the three items I was trying to address:

- Support multiple section names
    - The code already supported this by extending the UIOMaticTreeController class and re-rooting the tree
    - The edit page and the list page had hard-coded references to `/uiomatic/uiomatic` that just needed to be section-aware
- Use v8 property groups
    - Reformatted the edit page to use property groups instead of tabs
    - This also makes the background a more readable white instead of the grey
- Use v8 editorService format for custom actions
    - Set the `view` property instead of `template`
    - Handled the `close` and `submit` actions, although I didn't refresh the list on the submit action, which might be something to consider in the future
