### PR TITLE
Fix for issue #155 - Only retrieve data for a listview editor when a …

### DIFF
--- a/src/UIOMatic/Web/UI/App_Plugins/UIOMatic/backoffice/views/fieldeditors/list.controller.js
+++ b/src/UIOMatic/Web/UI/App_Plugins/UIOMatic/backoffice/views/fieldeditors/list.controller.js
@@ -1,7 +1,9 @@
 ﻿angular.module("umbraco").controller("UIOMatic.FieldEditors.List",
     function ($scope, $location, uioMaticObjectResource, $routeParams) {
 
-        $scope.filterId = $routeParams.id.split("?")[0];
+        if ($routeParams.id.includes("?ta=")) {
+            $scope.filterId = $routeParams.id.split("?")[0];
+        }
         $scope.typeAlias = $scope.property.config.typeAlias;
         $scope.foreignKeyColumn = $scope.property.config.foreignKeyColumn;
 


### PR DESCRIPTION
Hi Tim,

Created this pull request to fix the issue mentioned in #155. 
Previously the listview editor was trying to fetch data even if the the parent record wasn't created so I'e added an extra check to prevent this but I'm not sure if this is the best way to fix this.

Cheers,
Jeff