### PR TITLE
Ensure that the correct dropdown option is selected according to the stored value

### DIFF
--- a/src/UIOMatic/Web/UI/App_Plugins/UIOMatic/backoffice/views/fieldeditors/dropdown.controller.js
+++ b/src/UIOMatic/Web/UI/App_Plugins/UIOMatic/backoffice/views/fieldeditors/dropdown.controller.js
@@ -27,7 +27,6 @@
                                     text: $interpolate($scope.property.config.textTemplate)(itm)
                                 }
                             });
-                            $scope.trackedBy = $scope.property.config.foreignKeyValueAlias;
                         });
                 } else {
                     $scope.items = [];
@@ -43,7 +42,6 @@
                                     text: $interpolate($scope.property.config.textTemplate)(itm)
                                 }
                             });
-                            $scope.trackedBy = $scope.property.config.valueColumn;
                         });
             }
         }

--- a/src/UIOMatic/Web/UI/App_Plugins/UIOMatic/backoffice/views/fieldeditors/dropdown.controller.js
+++ b/src/UIOMatic/Web/UI/App_Plugins/UIOMatic/backoffice/views/fieldeditors/dropdown.controller.js
@@ -27,6 +27,7 @@
                                     text: $interpolate($scope.property.config.textTemplate)(itm)
                                 }
                             });
+                            $scope.trackedBy = $scope.property.config.foreignKeyValueAlias;
                         });
                 } else {
                     $scope.items = [];
@@ -42,6 +43,7 @@
                                     text: $interpolate($scope.property.config.textTemplate)(itm)
                                 }
                             });
+                            $scope.trackedBy = $scope.property.config.valueColumn;
                         });
             }
         }

--- a/src/UIOMatic/Web/UI/App_Plugins/UIOMatic/backoffice/views/fieldeditors/dropdown.html
+++ b/src/UIOMatic/Web/UI/App_Plugins/UIOMatic/backoffice/views/fieldeditors/dropdown.html
@@ -1,5 +1,6 @@
 ﻿<div ng-controller="UIOMatic.FieldEditors.Dropdown">
-    <select ng-model="property.value" ng-options="item.value as item.text for item in items track by item[trackedBy]" ng-change="onChange()">
+    <select name="select" id="" ng-model="property.value">
         <option value="">---Please select---</option>
-    </select><br />
+        <option ng-repeat="item in items track by item.value" value="{{item.value}}">{{item.text}}</option>
+    </select>
 </div>

--- a/src/UIOMatic/Web/UI/App_Plugins/UIOMatic/backoffice/views/fieldeditors/dropdown.html
+++ b/src/UIOMatic/Web/UI/App_Plugins/UIOMatic/backoffice/views/fieldeditors/dropdown.html
@@ -1,5 +1,5 @@
 ﻿<div ng-controller="UIOMatic.FieldEditors.Dropdown">
-    <select ng-model="property.value" ng-options="item.value as item.text for item in items" ng-change="onChange()">
+    <select ng-model="property.value" ng-options="item.value as item.text for item in items track by item[trackedBy]" ng-change="onChange()">
         <option value="">---Please select---</option>
-    </select><br>
+    </select><br />
 </div>


### PR DESCRIPTION
When a drowdown value was selected and saved to the database the stored value was not reset after refreshing the page. Thus I supplemented the ng-options with `track by` and a variable `trackedBy` which is either the foreigKeyColumAlias or the ValueColumn (both which are set in the attribute configuration)