### PR TITLE
Fixed logic bug in fetching data

### DIFF
--- a/src/UIOMatic/Web/UI/App_Plugins/UIOMatic/backoffice/uiomatic/list.controller.js
+++ b/src/UIOMatic/Web/UI/App_Plugins/UIOMatic/backoffice/uiomatic/list.controller.js
@@ -53,7 +53,7 @@
             $scope.rows = 0;
             $scope.totalPages = 0;
 
-            if (!firstLoad) {
+            if (firstLoad) {
                 loadState();
             } else {
                 saveState();


### PR DESCRIPTION
This fixes issue #165 which is a logic bug in fetching data for the list controller.  It was saving state on the first load, and loading state after that.  In this PR that is fixed to load state the first time, and then save state after that.

The effect of this bug was that you couldn't change pages (it would load state and set the current page to 1 each time before fetching data) and you couldn't perform searches on the list view.