### PR TITLE
add a default view which displays a valid url to navigate to

### DIFF
--- a/src/UIOMatic/Constants.cs
+++ b/src/UIOMatic/Constants.cs
@@ -31,6 +31,7 @@ namespace UIOMatic
             public const string Rte = "rte";
             public const string Textarea = "textarea";
             public const string Textfield = "textfield";
+            public const string Link = "link";
 
             public static readonly IReadOnlyDictionary<string, string> ViewPaths = new Dictionary<string, string>
             {
@@ -55,7 +56,8 @@ namespace UIOMatic
                 { "radiobuttonlist", "~/app_plugins/uiomatic/backoffice/views/fieldeditors/radiobuttonlist.html"},
                 { "rte", "~/app_plugins/uiomatic/backoffice/views/fieldeditors/rte.html"},
                 { "textarea", "~/app_plugins/uiomatic/backoffice/views/fieldeditors/textarea.html"},
-                { "textfield", "~/app_plugins/uiomatic/backoffice/views/fieldeditors/textfield.html"}
+                { "textfield", "~/app_plugins/uiomatic/backoffice/views/fieldeditors/textfield.html"},
+                { "link", "~/app_plugins/uiomatic/backoffice/views/fieldeditors/link.html"}
             };
         }
 

--- a/src/UIOMatic/UIOMatic.csproj
+++ b/src/UIOMatic/UIOMatic.csproj
@@ -90,6 +90,8 @@
     <Content Include="Web\UI\App_Plugins\UIOMatic\backoffice\views\fieldeditors\datetimeoffset.html" />
     <Content Include="Web\UI\App_Plugins\UIOMatic\backoffice\views\fieldeditors\date.html" />
     <Content Include="Web\UI\App_Plugins\UIOMatic\backoffice\views\fieldeditors\label.controller.js" />
+    <Content Include="Web\UI\App_Plugins\UIOMatic\backoffice\views\fieldeditors\link.controller.js" />
+    <Content Include="Web\UI\App_Plugins\UIOMatic\backoffice\views\fieldeditors\link.html" />
     <Content Include="Web\UI\App_Plugins\UIOMatic\backoffice\views\fieldeditors\pickers.object.controller.js" />
     <Content Include="Web\UI\App_Plugins\UIOMatic\backoffice\views\fieldeditors\pickers.object.html" />
     <Content Include="Web\UI\App_Plugins\UIOMatic\backoffice\views\fieldviews\label.html" />

--- a/src/UIOMatic/Web/UI/App_Plugins/UIOMatic/backoffice/views/fieldeditors/link.controller.js
+++ b/src/UIOMatic/Web/UI/App_Plugins/UIOMatic/backoffice/views/fieldeditors/link.controller.js
@@ -1,0 +1,25 @@
+﻿angular.module("umbraco").controller("UIOMatic.FieldEditors.Link",
+    function ($scope) {
+
+        var urlExpression = /[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_\+.~#?&//=]*)?/gi;
+        var urlRegex = new RegExp(urlExpression);
+
+        function init() {
+            load();
+        }
+
+        function load(value) {
+            if ($scope.property.config.URL && $scope.property.config.URL.match(urlRegex)) {
+                $scope.labelValue = $scope.property.config.URL
+            }
+        }
+
+        if ($scope.valuesLoaded) {
+            init();
+        } else {
+            var unsubscribe = $scope.$on('valuesLoaded', function () {
+                init();
+                unsubscribe();
+            });
+        }
+    });

--- a/src/UIOMatic/Web/UI/App_Plugins/UIOMatic/backoffice/views/fieldeditors/link.html
+++ b/src/UIOMatic/Web/UI/App_Plugins/UIOMatic/backoffice/views/fieldeditors/link.html
@@ -1,0 +1,3 @@
+﻿<span ng-controller="UIOMatic.FieldEditors.Link">
+    <a ng-href="{{labelValue}}" target="_blank">{{ labelValue }}</a>
+</span>

--- a/src/UIOMatic/Web/UI/App_Plugins/UIOMatic/package.manifest
+++ b/src/UIOMatic/Web/UI/App_Plugins/UIOMatic/package.manifest
@@ -196,6 +196,7 @@
 		'~/App_Plugins/UIOMatic/backoffice/views/fieldeditors/list.controller.js',
 		'~/App_Plugins/UIOMatic/backoffice/views/fieldeditors/rte.controller.js',
 		'~/App_Plugins/UIOMatic/backoffice/views/fieldeditors/map.controller.js',
+		'~/App_Plugins/UIOMatic/backoffice/views/fieldeditors/link.controller.js',
 
 		'~/App_Plugins/UIOMatic/backoffice/views/fieldfilters/dropdown.controller.js',
 


### PR DESCRIPTION
I've added the option to add an URL (only if it's valid, via regex check) according to issue https://github.com/TimGeyssens/UIOMatic/issues/116. 
I'm using this in one of my own projects so I thought it actually would be nice to create a pull request to get it into the original package.