### PR TITLE
swaps load/save of state to prevent new state values being overwritten

### DIFF
--- a/src/UIOMatic/Web/UI/App_Plugins/UIOMatic/backoffice/uiomatic/list.controller.js
+++ b/src/UIOMatic/Web/UI/App_Plugins/UIOMatic/backoffice/uiomatic/list.controller.js
@@ -62,10 +62,9 @@
             $scope.totalPages = 0;
 
             if (firstLoad) {
-                saveState();
-
-            } else {
                 loadState();
+            } else {
+                saveState();
             }
 
             uioMaticObjectResource.getPaged($scope.typeAlias, $scope.itemsPerPage, $scope.currentPage,


### PR DESCRIPTION
When filter options are selected, the filter values are overwritten by the currently saved state instead of being maintained and then passed on to the load/get request.