### PR TITLE
185: Use app scope instead of local controller scope for valuesLoaded

### DIFF
--- a/src/UIOMatic/Web/UI/App_Plugins/UIOMatic/backoffice/views/fieldeditors/checkboxlist.controller.js
+++ b/src/UIOMatic/Web/UI/App_Plugins/UIOMatic/backoffice/views/fieldeditors/checkboxlist.controller.js
@@ -41,7 +41,7 @@ angular.module("umbraco").controller("UIOMatic.FieldEditors.Checkboxlist",
         }
 
         var appScope = $scope;
-        while (typeof appScope === 'object' && typeof appScope.activeApp === 'undefined') appScope = appScope.$parent;
+        while (appScope && typeof appScope === 'object' && typeof appScope.currentSection === 'undefined') appScope = appScope.$parent;
 
         if (appScope.valuesLoaded) {
             updateSelected();

--- a/src/UIOMatic/Web/UI/App_Plugins/UIOMatic/backoffice/views/fieldeditors/checkboxlist.controller.js
+++ b/src/UIOMatic/Web/UI/App_Plugins/UIOMatic/backoffice/views/fieldeditors/checkboxlist.controller.js
@@ -40,11 +40,14 @@ angular.module("umbraco").controller("UIOMatic.FieldEditors.Checkboxlist",
             $scope.property.value = val.join($scope.delimiter);
         }
 
-        if ($scope.valuesLoaded) {
+        var appScope = $scope;
+        while (typeof appScope === 'object' && typeof appScope.activeApp === 'undefined') appScope = appScope.$parent;
+
+        if (appScope.valuesLoaded) {
             updateSelected();
             init();
         } else {
-            var unsubscribe = $scope.$on('valuesLoaded', function () {
+            var unsubscribe = appScope.$on('valuesLoaded', function () {
                 updateSelected();
                 init();
                 unsubscribe();

--- a/src/UIOMatic/Web/UI/App_Plugins/UIOMatic/backoffice/views/fieldeditors/datetime.controller.js
+++ b/src/UIOMatic/Web/UI/App_Plugins/UIOMatic/backoffice/views/fieldeditors/datetime.controller.js
@@ -126,11 +126,13 @@
             });
         }
 
+        var appScope = $scope;
+        while (typeof appScope === 'object' && typeof appScope.activeApp === 'undefined') appScope = appScope.$parent;
 
-        if ($scope.valuesLoaded) {
+        if (appScope.valuesLoaded) {
             init();
         } else {
-            var unsubscribe = $scope.$on('valuesLoaded', function () {
+            var unsubscribe = appScope.$on('valuesLoaded', function () {
                 init();
                 unsubscribe();
             });

--- a/src/UIOMatic/Web/UI/App_Plugins/UIOMatic/backoffice/views/fieldeditors/datetime.controller.js
+++ b/src/UIOMatic/Web/UI/App_Plugins/UIOMatic/backoffice/views/fieldeditors/datetime.controller.js
@@ -127,7 +127,7 @@
         }
 
         var appScope = $scope;
-        while (typeof appScope === 'object' && typeof appScope.activeApp === 'undefined') appScope = appScope.$parent;
+        while (appScope && typeof appScope === 'object' && typeof appScope.currentSection === 'undefined') appScope = appScope.$parent;
 
         if (appScope.valuesLoaded) {
             init();

--- a/src/UIOMatic/Web/UI/App_Plugins/UIOMatic/backoffice/views/fieldeditors/dropdown.controller.js
+++ b/src/UIOMatic/Web/UI/App_Plugins/UIOMatic/backoffice/views/fieldeditors/dropdown.controller.js
@@ -58,7 +58,7 @@
         }
 
         var appScope = $scope;
-        while (typeof appScope === 'object' && typeof appScope.activeApp === 'undefined') appScope = appScope.$parent;
+        while (appScope && typeof appScope === 'object' && typeof appScope.currentSection === 'undefined') appScope = appScope.$parent;
 
         if (appScope.valuesLoaded) {
             init();

--- a/src/UIOMatic/Web/UI/App_Plugins/UIOMatic/backoffice/views/fieldeditors/dropdown.controller.js
+++ b/src/UIOMatic/Web/UI/App_Plugins/UIOMatic/backoffice/views/fieldeditors/dropdown.controller.js
@@ -57,10 +57,13 @@
             $rootScope.$broadcast('dropdownChanged', $scope.property);
         }
 
-        if ($scope.valuesLoaded) {
+        var appScope = $scope;
+        while (typeof appScope === 'object' && typeof appScope.activeApp === 'undefined') appScope = appScope.$parent;
+
+        if (appScope.valuesLoaded) {
             init();
         } else {
-            var unsubscribe = $scope.$on('valuesLoaded', function () {
+            var unsubscribe = appScope.$on('valuesLoaded', function () {
                 init();
                 unsubscribe();
             });

--- a/src/UIOMatic/Web/UI/App_Plugins/UIOMatic/backoffice/views/fieldeditors/label.controller.js
+++ b/src/UIOMatic/Web/UI/App_Plugins/UIOMatic/backoffice/views/fieldeditors/label.controller.js
@@ -9,10 +9,13 @@
             }
         }
 
-        if ($scope.valuesLoaded || $scope.property.view.indexOf("fieldviews") > -1) {
+        var appScope = $scope;
+        while (typeof appScope === 'object' && typeof appScope.activeApp === 'undefined') appScope = appScope.$parent;
+
+        if (appScope.valuesLoaded || $scope.property.view.indexOf("fieldviews") > -1) {
             init();
         } else {
-            var unsubscribe = $scope.$on('valuesLoaded', function () {
+            var unsubscribe = appScope.$on('valuesLoaded', function () {
                 init();
                 unsubscribe();
             });

--- a/src/UIOMatic/Web/UI/App_Plugins/UIOMatic/backoffice/views/fieldeditors/label.controller.js
+++ b/src/UIOMatic/Web/UI/App_Plugins/UIOMatic/backoffice/views/fieldeditors/label.controller.js
@@ -10,7 +10,7 @@
         }
 
         var appScope = $scope;
-        while (typeof appScope === 'object' && typeof appScope.activeApp === 'undefined') appScope = appScope.$parent;
+        while (appScope && typeof appScope === 'object' && typeof appScope.currentSection === 'undefined') appScope = appScope.$parent;
 
         if (appScope.valuesLoaded || $scope.property.view.indexOf("fieldviews") > -1) {
             init();

--- a/src/UIOMatic/Web/UI/App_Plugins/UIOMatic/backoffice/views/fieldeditors/link.controller.js
+++ b/src/UIOMatic/Web/UI/App_Plugins/UIOMatic/backoffice/views/fieldeditors/link.controller.js
@@ -15,7 +15,7 @@
         }
 
         var appScope = $scope;
-        while (typeof appScope === 'object' && typeof appScope.activeApp === 'undefined') appScope = appScope.$parent;
+        while (appScope && typeof appScope === 'object' && typeof appScope.currentSection === 'undefined') appScope = appScope.$parent;
 
         if (appScope.valuesLoaded) {
             init();

--- a/src/UIOMatic/Web/UI/App_Plugins/UIOMatic/backoffice/views/fieldeditors/link.controller.js
+++ b/src/UIOMatic/Web/UI/App_Plugins/UIOMatic/backoffice/views/fieldeditors/link.controller.js
@@ -14,10 +14,13 @@
             }
         }
 
-        if ($scope.valuesLoaded) {
+        var appScope = $scope;
+        while (typeof appScope === 'object' && typeof appScope.activeApp === 'undefined') appScope = appScope.$parent;
+
+        if (appScope.valuesLoaded) {
             init();
         } else {
-            var unsubscribe = $scope.$on('valuesLoaded', function () {
+            var unsubscribe = appScope.$on('valuesLoaded', function () {
                 init();
                 unsubscribe();
             });

--- a/src/UIOMatic/Web/UI/App_Plugins/UIOMatic/backoffice/views/fieldeditors/list.controller.js
+++ b/src/UIOMatic/Web/UI/App_Plugins/UIOMatic/backoffice/views/fieldeditors/list.controller.js
@@ -107,10 +107,13 @@
             $location.url(url);
         }
 
-        if ($scope.valuesLoaded) {
+        var appScope = $scope;
+        while (typeof appScope === 'object' && typeof appScope.activeApp === 'undefined') appScope = appScope.$parent;
+
+        if (appScope.valuesLoaded) {
             init();
         } else {
-            var unsubscribe = $scope.$on('valuesLoaded', function () {
+            var unsubscribe = appScope.$on('valuesLoaded', function () {
                 init();
                 unsubscribe();
             });

--- a/src/UIOMatic/Web/UI/App_Plugins/UIOMatic/backoffice/views/fieldeditors/list.controller.js
+++ b/src/UIOMatic/Web/UI/App_Plugins/UIOMatic/backoffice/views/fieldeditors/list.controller.js
@@ -108,7 +108,7 @@
         }
 
         var appScope = $scope;
-        while (typeof appScope === 'object' && typeof appScope.activeApp === 'undefined') appScope = appScope.$parent;
+        while (appScope && typeof appScope === 'object' && typeof appScope.currentSection === 'undefined') appScope = appScope.$parent;
 
         if (appScope.valuesLoaded) {
             init();

--- a/src/UIOMatic/Web/UI/App_Plugins/UIOMatic/backoffice/views/fieldeditors/map.controller.js
+++ b/src/UIOMatic/Web/UI/App_Plugins/UIOMatic/backoffice/views/fieldeditors/map.controller.js
@@ -100,10 +100,13 @@
 	        }
 	    }
 
-	    if ($scope.valuesLoaded) {
+        var appScope = $scope;
+        while (typeof appScope === 'object' && typeof appScope.activeApp === 'undefined') appScope = appScope.$parent;
+
+	    if (appScope.valuesLoaded) {
 	        init();
 	    } else {
-	        var unsubscribe = $scope.$on('valuesLoaded', function () {
+	        var unsubscribe = appScope.$on('valuesLoaded', function () {
 	            init();
 	            unsubscribe();
 	        });

--- a/src/UIOMatic/Web/UI/App_Plugins/UIOMatic/backoffice/views/fieldeditors/map.controller.js
+++ b/src/UIOMatic/Web/UI/App_Plugins/UIOMatic/backoffice/views/fieldeditors/map.controller.js
@@ -101,7 +101,7 @@
 	    }
 
         var appScope = $scope;
-        while (typeof appScope === 'object' && typeof appScope.activeApp === 'undefined') appScope = appScope.$parent;
+        while (appScope && typeof appScope === 'object' && typeof appScope.currentSection === 'undefined') appScope = appScope.$parent;
 
 	    if (appScope.valuesLoaded) {
 	        init();

--- a/src/UIOMatic/Web/UI/App_Plugins/UIOMatic/backoffice/views/fieldeditors/pickers.content.controller.js
+++ b/src/UIOMatic/Web/UI/App_Plugins/UIOMatic/backoffice/views/fieldeditors/pickers.content.controller.js
@@ -51,10 +51,13 @@
             }
         };
 
-        if ($scope.valuesLoaded) {
+        var appScope = $scope;
+        while (typeof appScope === 'object' && typeof appScope.activeApp === 'undefined') appScope = appScope.$parent;
+
+        if (appScope.valuesLoaded) {
             init();
         } else {
-            var unsubscribe = $scope.$on('valuesLoaded', function () {
+            var unsubscribe = appScope.$on('valuesLoaded', function () {
                 init();
                 unsubscribe();
             });

--- a/src/UIOMatic/Web/UI/App_Plugins/UIOMatic/backoffice/views/fieldeditors/pickers.content.controller.js
+++ b/src/UIOMatic/Web/UI/App_Plugins/UIOMatic/backoffice/views/fieldeditors/pickers.content.controller.js
@@ -52,7 +52,7 @@
         };
 
         var appScope = $scope;
-        while (typeof appScope === 'object' && typeof appScope.activeApp === 'undefined') appScope = appScope.$parent;
+        while (appScope && typeof appScope === 'object' && typeof appScope.currentSection === 'undefined') appScope = appScope.$parent;
 
         if (appScope.valuesLoaded) {
             init();

--- a/src/UIOMatic/Web/UI/App_Plugins/UIOMatic/backoffice/views/fieldeditors/pickers.media.controller.js
+++ b/src/UIOMatic/Web/UI/App_Plugins/UIOMatic/backoffice/views/fieldeditors/pickers.media.controller.js
@@ -50,7 +50,7 @@
         };
 
         var appScope = $scope;
-        while (typeof appScope === 'object' && typeof appScope.activeApp === 'undefined') appScope = appScope.$parent;
+        while (appScope && typeof appScope === 'object' && typeof appScope.currentSection === 'undefined') appScope = appScope.$parent;
 
         if (appScope.valuesLoaded) {
             init();

--- a/src/UIOMatic/Web/UI/App_Plugins/UIOMatic/backoffice/views/fieldeditors/pickers.media.controller.js
+++ b/src/UIOMatic/Web/UI/App_Plugins/UIOMatic/backoffice/views/fieldeditors/pickers.media.controller.js
@@ -49,10 +49,13 @@
             }
         };
 
-        if ($scope.valuesLoaded) {
+        var appScope = $scope;
+        while (typeof appScope === 'object' && typeof appScope.activeApp === 'undefined') appScope = appScope.$parent;
+
+        if (appScope.valuesLoaded) {
             init();
         } else {
-            var unsubscribe = $scope.$on('valuesLoaded', function () {
+            var unsubscribe = appScope.$on('valuesLoaded', function () {
                 init();
                 unsubscribe();
             });

--- a/src/UIOMatic/Web/UI/App_Plugins/UIOMatic/backoffice/views/fieldeditors/pickers.member.controller.js
+++ b/src/UIOMatic/Web/UI/App_Plugins/UIOMatic/backoffice/views/fieldeditors/pickers.member.controller.js
@@ -53,7 +53,7 @@
         };
 
         var appScope = $scope;
-        while (typeof appScope === 'object' && typeof appScope.activeApp === 'undefined') appScope = appScope.$parent;
+        while (appScope && typeof appScope === 'object' && typeof appScope.currentSection === 'undefined') appScope = appScope.$parent;
 
         if (appScope.valuesLoaded) {
             init();

--- a/src/UIOMatic/Web/UI/App_Plugins/UIOMatic/backoffice/views/fieldeditors/pickers.member.controller.js
+++ b/src/UIOMatic/Web/UI/App_Plugins/UIOMatic/backoffice/views/fieldeditors/pickers.member.controller.js
@@ -52,10 +52,13 @@
             }
         };
 
-        if ($scope.valuesLoaded) {
+        var appScope = $scope;
+        while (typeof appScope === 'object' && typeof appScope.activeApp === 'undefined') appScope = appScope.$parent;
+
+        if (appScope.valuesLoaded) {
             init();
         } else {
-            var unsubscribe = $scope.$on('valuesLoaded', function () {
+            var unsubscribe = appScope.$on('valuesLoaded', function () {
                 init();
                 unsubscribe();
             });

--- a/src/UIOMatic/Web/UI/App_Plugins/UIOMatic/backoffice/views/fieldeditors/pickers.object.controller.js
+++ b/src/UIOMatic/Web/UI/App_Plugins/UIOMatic/backoffice/views/fieldeditors/pickers.object.controller.js
@@ -60,10 +60,13 @@
             });
         }
 
-        if ($scope.valuesLoaded) {
+        var appScope = $scope;
+        while (typeof appScope === 'object' && typeof appScope.activeApp === 'undefined') appScope = appScope.$parent;
+
+        if (appScope.valuesLoaded) {
             init();
         } else {
-            var unsubscribe = $scope.$on('valuesLoaded', function () {
+            var unsubscribe = appScope.$on('valuesLoaded', function () {
                 init();
                 unsubscribe();
             });

--- a/src/UIOMatic/Web/UI/App_Plugins/UIOMatic/backoffice/views/fieldeditors/pickers.object.controller.js
+++ b/src/UIOMatic/Web/UI/App_Plugins/UIOMatic/backoffice/views/fieldeditors/pickers.object.controller.js
@@ -61,7 +61,7 @@
         }
 
         var appScope = $scope;
-        while (typeof appScope === 'object' && typeof appScope.activeApp === 'undefined') appScope = appScope.$parent;
+        while (appScope && typeof appScope === 'object' && typeof appScope.currentSection === 'undefined') appScope = appScope.$parent;
 
         if (appScope.valuesLoaded) {
             init();

--- a/src/UIOMatic/Web/UI/App_Plugins/UIOMatic/backoffice/views/fieldeditors/pickers.user.controller.js
+++ b/src/UIOMatic/Web/UI/App_Plugins/UIOMatic/backoffice/views/fieldeditors/pickers.user.controller.js
@@ -7,10 +7,13 @@
             });
         };
 
-        if ($scope.valuesLoaded) {
+        var appScope = $scope;
+        while (typeof appScope === 'object' && typeof appScope.activeApp === 'undefined') appScope = appScope.$parent;
+
+        if (appScope.valuesLoaded) {
             init();
         } else {
-            var unsubscribe = $scope.$on('valuesLoaded', function () {
+            var unsubscribe = appScope.$on('valuesLoaded', function () {
                 init();
                 unsubscribe();
             });

--- a/src/UIOMatic/Web/UI/App_Plugins/UIOMatic/backoffice/views/fieldeditors/pickers.user.controller.js
+++ b/src/UIOMatic/Web/UI/App_Plugins/UIOMatic/backoffice/views/fieldeditors/pickers.user.controller.js
@@ -8,7 +8,7 @@
         };
 
         var appScope = $scope;
-        while (typeof appScope === 'object' && typeof appScope.activeApp === 'undefined') appScope = appScope.$parent;
+        while (appScope && typeof appScope === 'object' && typeof appScope.currentSection === 'undefined') appScope = appScope.$parent;
 
         if (appScope.valuesLoaded) {
             init();

--- a/src/UIOMatic/Web/UI/App_Plugins/UIOMatic/backoffice/views/fieldeditors/pickers.users.controller.js
+++ b/src/UIOMatic/Web/UI/App_Plugins/UIOMatic/backoffice/views/fieldeditors/pickers.users.controller.js
@@ -75,7 +75,7 @@
         }
 
         var appScope = $scope;
-        while (typeof appScope === 'object' && typeof appScope.activeApp === 'undefined') appScope = appScope.$parent;
+        while (appScope && typeof appScope === 'object' && typeof appScope.currentSection === 'undefined') appScope = appScope.$parent;
 
         if (appScope.valuesLoaded) {
             init();

--- a/src/UIOMatic/Web/UI/App_Plugins/UIOMatic/backoffice/views/fieldeditors/pickers.users.controller.js
+++ b/src/UIOMatic/Web/UI/App_Plugins/UIOMatic/backoffice/views/fieldeditors/pickers.users.controller.js
@@ -74,10 +74,13 @@
             });
         }
 
-        if ($scope.valuesLoaded) {
+        var appScope = $scope;
+        while (typeof appScope === 'object' && typeof appScope.activeApp === 'undefined') appScope = appScope.$parent;
+
+        if (appScope.valuesLoaded) {
             init();
         } else {
-            var unsubscribe = $scope.$on('valuesLoaded', function () {
+            var unsubscribe = appScope.$on('valuesLoaded', function () {
                 init();
                 unsubscribe();
             });

--- a/src/UIOMatic/Web/UI/App_Plugins/UIOMatic/backoffice/views/fieldeditors/radiobuttonlist.controller.js
+++ b/src/UIOMatic/Web/UI/App_Plugins/UIOMatic/backoffice/views/fieldeditors/radiobuttonlist.controller.js
@@ -17,7 +17,7 @@
         }
 
         var appScope = $scope;
-        while (typeof appScope === 'object' && typeof appScope.activeApp === 'undefined') appScope = appScope.$parent;
+        while (appScope && typeof appScope === 'object' && typeof appScope.currentSection === 'undefined') appScope = appScope.$parent;
 
         if (appScope.valuesLoaded) {
             init();

--- a/src/UIOMatic/Web/UI/App_Plugins/UIOMatic/backoffice/views/fieldeditors/radiobuttonlist.controller.js
+++ b/src/UIOMatic/Web/UI/App_Plugins/UIOMatic/backoffice/views/fieldeditors/radiobuttonlist.controller.js
@@ -16,10 +16,13 @@
             $scope.property.value = val;
         }
 
-        if ($scope.valuesLoaded) {
+        var appScope = $scope;
+        while (typeof appScope === 'object' && typeof appScope.activeApp === 'undefined') appScope = appScope.$parent;
+
+        if (appScope.valuesLoaded) {
             init();
         } else {
-            var unsubscribe = $scope.$on('valuesLoaded', function () {
+            var unsubscribe = appScope.$on('valuesLoaded', function () {
                 init();
                 unsubscribe();
             });

--- a/src/UIOMatic/Web/UI/App_Plugins/UIOMatic/backoffice/views/fieldeditors/rte.controller.js
+++ b/src/UIOMatic/Web/UI/App_Plugins/UIOMatic/backoffice/views/fieldeditors/rte.controller.js
@@ -27,10 +27,13 @@ angular.module("umbraco").controller("UIOMatic.FieldEditors.RTE", function ($sco
         }, true);
     }
 
-    if ($scope.valuesLoaded) {
+    var appScope = $scope;
+    while (typeof appScope === 'object' && typeof appScope.activeApp === 'undefined') appScope = appScope.$parent;
+
+    if (appScope.valuesLoaded) {
         init();
     } else {
-        $scope.$on('valuesLoaded', function () {
+        appScope.$on('valuesLoaded', function () {
             init();
             $scope.valuesLoaded = true;
         });

--- a/src/UIOMatic/Web/UI/App_Plugins/UIOMatic/backoffice/views/fieldeditors/rte.controller.js
+++ b/src/UIOMatic/Web/UI/App_Plugins/UIOMatic/backoffice/views/fieldeditors/rte.controller.js
@@ -28,7 +28,7 @@ angular.module("umbraco").controller("UIOMatic.FieldEditors.RTE", function ($sco
     }
 
     var appScope = $scope;
-    while (typeof appScope === 'object' && typeof appScope.activeApp === 'undefined') appScope = appScope.$parent;
+    while (appScope && typeof appScope === 'object' && typeof appScope.currentSection === 'undefined') appScope = appScope.$parent;
 
     if (appScope.valuesLoaded) {
         init();


### PR DESCRIPTION
This resolves the race condition from #185 by going up the scope tree until it finds the app scope set in the Edit.html page itself, or at least one that is not isolated from the app scope and so can see the same properties and events.  It then uses this app scope to check for whether or not the values are loaded, and if not to listen for when they have been loaded.