### PR TITLE
187: Enable strict filtering on tab name

### DIFF
--- a/src/UIOMatic/Web/UI/App_Plugins/UIOMatic/backoffice/apps/uiomaticContent.html
+++ b/src/UIOMatic/Web/UI/App_Plugins/UIOMatic/backoffice/apps/uiomaticContent.html
@@ -8,7 +8,7 @@
                 </div>
 
                 <div class="umb-group-panel__content">
-                    <div class="umb-property" ng-repeat="property in properties | removeProperty:type.nameFieldKey | filter:{tab: group.label}">
+                    <div class="umb-property" ng-repeat="property in properties | removeProperty:type.nameFieldKey | filter:{tab: group.label}:true">
                         <umb-control-group label="{{property.name}}" description="{{property.description}}" ng-if="!queryString[property.columnName]">
                             <div ng-include="property.view"></div>
                         </umb-control-group>


### PR DESCRIPTION
This fixes #187 by using the `comparator` argument on the `filter` directive as defined in [the documentation](https://docs.angularjs.org/api/ng/filter/filter).  Setting the argument to true enables a strict `equals` check on the tab name, rather than the default `contains` check.