### PR TITLE
Fix sections so that you can inherit the tree controller

### DIFF
--- a/src/UIOMatic.Site/ExampleCode/TestExtraSection.cs
+++ b/src/UIOMatic.Site/ExampleCode/TestExtraSection.cs
@@ -1,0 +1,36 @@
+﻿using UIOMatic.Interfaces;
+using UIOMatic.Web.Controllers;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Composing;
+using Umbraco.Cms.Core.Events;
+using Umbraco.Cms.Core.Sections;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Core.Trees;
+using Umbraco.Cms.Web.BackOffice.Trees;
+using Umbraco.Cms.Web.Common.Attributes;
+
+namespace UIOMatic.Site.ExampleCode
+{
+    public class TestExtraSectionComposer : IComposer
+    {
+        public void Compose(IUmbracoBuilder builder)
+        {
+            builder.AddSection<TestExtraSection>();
+        }
+    }
+
+    public class TestExtraSection : ISection
+    {
+        public string Alias => "comments";
+        public string Name => "Comments";
+    }
+
+    [Tree("comments", "uiomatic", TreeTitle = "Comments", SortOrder = 1)]
+    [PluginController("UIOMatic")]
+    public class TestExtraSectionTreeController : UIOMaticTreeController
+    {
+        public TestExtraSectionTreeController(ILocalizedTextService localizedTextService, UmbracoApiControllerTypeCollection umbracoApiControllerTypeCollection, IMenuItemCollectionFactory menuItemCollectionFactory, IEventAggregator eventAggregator, IUIOMaticHelper helper, IUIOMaticObjectService uioMaticObjectService) : base(localizedTextService, umbracoApiControllerTypeCollection, menuItemCollectionFactory, eventAggregator, helper, uioMaticObjectService)
+        {
+        }
+    }
+}

--- a/src/UIOMatic/Web/Controllers/UIOMaticTreeController.cs
+++ b/src/UIOMatic/Web/Controllers/UIOMaticTreeController.cs
@@ -58,7 +58,7 @@ namespace UIOMatic.Web.Controllers
 
             var root = rootResult.Value;
 
-            root.Path = $"{Constants.SectionAlias}/{Constants.TreeAlias}/";
+            root.Path = $"{SectionAlias}/{TreeAlias}/";
             root.Icon = "icon-wand";
             root.HasChildren = true;
             root.MenuUrl = null;
@@ -97,7 +97,7 @@ namespace UIOMatic.Web.Controllers
                                 attri.FolderName,
                                 attri.FolderIcon,
                                 true,
-                                "uiomatic");
+                                SectionAlias);
 
                             nodes.Add(node);
                         }
@@ -111,7 +111,7 @@ namespace UIOMatic.Web.Controllers
                                 attri.FolderName,
                                 attri.FolderIcon,
                                 false,
-                                "uiomatic/uiomatic/list/" + alias);
+                                $"{SectionAlias}/{TreeAlias}/list/" + alias);
 
                             node.SetContainerStyle();
 
@@ -128,7 +128,7 @@ namespace UIOMatic.Web.Controllers
                                attri.FolderName,
                                attri.FolderIcon,
                                true,
-                               "uiomatic");
+                               SectionAlias);
 
                         nodes.Add(node);
                     }


### PR DESCRIPTION
The documentation on https://timgeyssens.gitbook.io/ui-o-matic/custom-sections stated that you can inherit the UIOMatic tree controller and that everything would work however, this isn't the case. If you follow all the steps, then whenever you click a node in your new section, it'll redirect you to the default UI-O-Matic section.

This PR will fix that, allowing you to have your own section for UI-O-Matic. Also added some test code to the site project.

Also, is it possible to do PRs for the documentation? Seems like it is kinda out of date